### PR TITLE
Add UIViewController extension to present BottomHalfModal

### DIFF
--- a/BottomHalfModal/BottomHalfModalNavigationController.swift
+++ b/BottomHalfModal/BottomHalfModalNavigationController.swift
@@ -9,34 +9,8 @@
 import UIKit
 
 open class BottomHalfModalNavigationController: UINavigationController {
-    public init() {
-        super.init(navigationBarClass: UINavigationBar.self, toolbarClass: nil)
-        commonInit()
-    }
-
-    public override init(rootViewController: UIViewController) {
-        super.init(navigationBarClass: UINavigationBar.self, toolbarClass: nil)
-        viewControllers = [rootViewController]
-        commonInit()
-    }
-
-    @available(*, unavailable)
-    public override init(nibName nibNameOrNil: String?, bundle nibBundleOrNil: Bundle?) {
-        super.init(nibName: nibNameOrNil, bundle: nibBundleOrNil)
-    }
-
-    @available(*, unavailable)
-    required public init?(coder aDecoder: NSCoder) {
-        fatalError("init(coder:) has not been implemented")
-    }
-
-    func commonInit() {
-        modalPresentationStyle = .custom
-        transitioningDelegate = self
-    }
-
     override open func pushViewController(_ viewController: UIViewController, animated: Bool) {
-        if let vc = viewController as? SheetContentHeightModifiable {
+        if children.count > 0, let vc = viewController as? SheetContentHeightModifiable {
             sheetContentHeight = vc.sheetContentHeightToModify
         }
         super.pushViewController(viewController, animated: animated)
@@ -58,32 +32,3 @@ open class BottomHalfModalNavigationController: UINavigationController {
         return vcs
     }
 }
-
-// MARK: - UIViewControllerTransitioningDelegate
-
-extension BottomHalfModalNavigationController: UIViewControllerTransitioningDelegate {
-    public func presentationController(
-        forPresented presented: UIViewController,
-        presenting: UIViewController?,
-        source: UIViewController
-        ) -> UIPresentationController? {
-        guard presented == self else { return nil }
-        return SheetPresentationController(presentedViewController: presented, presenting: presenting)
-    }
-
-    public func animationController(
-        forPresented presented: UIViewController,
-        presenting: UIViewController,
-        source: UIViewController
-        ) -> UIViewControllerAnimatedTransitioning? {
-        guard presented == self else { return nil }
-        return SheetAnimationController(forPresenting: true)
-    }
-
-    public func animationController(forDismissed dismissed: UIViewController) -> UIViewControllerAnimatedTransitioning? {
-        guard dismissed == self else { return nil }
-        return SheetAnimationController(forPresenting: false)
-    }
-
-}
-

--- a/BottomHalfModal/SheetContentHeight.swift
+++ b/BottomHalfModal/SheetContentHeight.swift
@@ -1,0 +1,13 @@
+//
+//  SheetContentHeight.swift
+//  BottomHalfModal
+//
+//  Created by masamichi on 2019/10/09.
+//  Copyright © 2019 merpay, Inc. All rights reserved.
+//
+
+import Foundation
+
+public enum SheetContentHeight {
+    public static let `default`: CGFloat = 320
+}

--- a/BottomHalfModal/SheetContentHeightModifiable.swift
+++ b/BottomHalfModal/SheetContentHeightModifiable.swift
@@ -1,0 +1,29 @@
+//
+//  SheetContentHeightModifiable.swift
+//  BottomHalfModal
+//
+//  Created by masamichi on 2019/10/09.
+//  Copyright © 2019 merpay, Inc. All rights reserved.
+//
+
+import UIKit
+
+public protocol SheetContentHeightModifiable {
+    var sheetContentHeightToModify: CGFloat { get }
+    func adjustFrameToSheetContentHeightIfNeeded(with coordinator: UIViewControllerTransitionCoordinator)
+}
+
+extension SheetContentHeightModifiable where Self: UIViewController {
+    public func adjustFrameToSheetContentHeightIfNeeded() {
+        self.sheetContentHeight = self.sheetContentHeightToModify
+    }
+
+    public func adjustFrameToSheetContentHeightIfNeeded(with coordinator: UIViewControllerTransitionCoordinator) {
+        coordinator.animate(alongsideTransition: nil) { [weak self] _ in
+            guard let strongSelf = self else { return }
+            if strongSelf.navigationController?.topViewController == strongSelf {
+                strongSelf.adjustFrameToSheetContentHeightIfNeeded()
+            }
+        }
+    }
+}

--- a/BottomHalfModal/SheetControllerContentSizing.swift
+++ b/BottomHalfModal/SheetControllerContentSizing.swift
@@ -1,0 +1,50 @@
+//
+//  SheetControllerContentSizing.swift
+//  BottomHalfModal
+//
+//  Created by masamichi on 2019/10/09.
+//  Copyright © 2019 merpay, Inc. All rights reserved.
+//
+
+import UIKit
+
+protocol SheetControllerContentSizing {
+    var sheetContentHeight: CGFloat { get set }
+}
+
+extension UIViewController: SheetControllerContentSizing {
+
+    /**
+     to invoke SheetPresentationController - preferredContentSizeDidChange,
+     if self.navigationController exists, change its preferredContentSize instead of this to invoke correctly.
+     */
+    var sheetContentHeight: CGFloat {
+        get {
+            guard let nav = navigationController else { return preferredContentSize.height }
+            return nav.preferredContentSize.height
+        }
+        set {
+            let width = view.bounds.width
+            let additionalBottomHeight: CGFloat
+            if let windowWithSafeArea = UIApplication.shared.windows.first(where: { $0.safeAreaInsets.bottom > 0 }) {
+                // If there is a window with safeArea, we use SafeAreaInsets of it because SafeAreaInsets of self.view is not updated in viewDidAppear in the first view controller.
+                // Keywindow is sometimes different from application main window(ex. Banner), we don't use UIApplication.shared.keyWindow.
+                additionalBottomHeight = windowWithSafeArea.safeAreaInsets.bottom
+            } else {
+                additionalBottomHeight = 0
+            }
+            if let nav = navigationController {
+                nav.preferredContentSize = CGSize(width: width, height: newValue + additionalBottomHeight)
+            } else {
+                preferredContentSize = CGSize(width: view.bounds.width, height: newValue + additionalBottomHeight)
+            }
+        }
+    }
+
+    // MARK: Convenience methods
+
+    public func animate(with keyboardNotification: Notification, safeAreaInsets: UIEdgeInsets = UIEdgeInsets.zero) {
+        guard let sheetPresentationController = navigationController?.presentationController as? SheetPresentationController else { return }
+        sheetPresentationController.animateContainerView(with: keyboardNotification, safeAreaInsets: safeAreaInsets)
+    }
+}

--- a/BottomHalfModal/SheetPresentationController.swift
+++ b/BottomHalfModal/SheetPresentationController.swift
@@ -6,77 +6,7 @@
 //  Copyright © 2018 merpay, Inc. All rights reserved.
 //
 
-import Foundation
 import UIKit
-
-// MARK: - SheetContentHeightModifiable
-
-public protocol SheetContentHeightModifiable {
-    var sheetContentHeightToModify: CGFloat { get }
-    func adjustFrameToSheetContentHeightIfNeeded(with coordinator: UIViewControllerTransitionCoordinator)
-}
-
-public enum SheetContentHeight {
-    public static let `default`: CGFloat = 320
-}
-
-// MARK: - SheetControllerContentSizing
-
-protocol SheetControllerContentSizing {
-    var sheetContentHeight: CGFloat { get set }
-}
-
-extension SheetContentHeightModifiable where Self: UIViewController {
-    public func adjustFrameToSheetContentHeightIfNeeded() {
-        self.sheetContentHeight = self.sheetContentHeightToModify
-    }
-
-    public func adjustFrameToSheetContentHeightIfNeeded(with coordinator: UIViewControllerTransitionCoordinator) {
-        coordinator.animate(alongsideTransition: nil) { [weak self] _ in
-            guard let strongSelf = self else { return }
-            if strongSelf.navigationController?.topViewController == strongSelf {
-                strongSelf.adjustFrameToSheetContentHeightIfNeeded()
-            }
-        }
-    }
-}
-
-extension UIViewController: SheetControllerContentSizing {
-
-    /**
-     to invoke SheetPresentationController - preferredContentSizeDidChange,
-     if self.navigationController exists, change its preferredContentSize instead of this to invoke correctly.
-     */
-    var sheetContentHeight: CGFloat {
-        get {
-            guard let nav = navigationController else { return preferredContentSize.height }
-            return nav.preferredContentSize.height
-        }
-        set {
-            let width = view.bounds.width
-            let additionalBottomHeight: CGFloat
-            if let windowWithSafeArea = UIApplication.shared.windows.first(where: { $0.safeAreaInsets.bottom > 0 }) {
-                // If there is a window with safeArea, we use SafeAreaInsets of it because SafeAreaInsets of self.view is not updated in viewDidAppear in the first view controller.
-                // Keywindow is sometimes different from application main window(ex. Banner), we don't use UIApplication.shared.keyWindow.
-                additionalBottomHeight = windowWithSafeArea.safeAreaInsets.bottom
-            } else {
-                additionalBottomHeight = 0
-            }
-            if let nav = navigationController {
-                nav.preferredContentSize = CGSize(width: width, height: newValue + additionalBottomHeight)
-            } else {
-                preferredContentSize = CGSize(width: view.bounds.width, height: newValue + additionalBottomHeight)
-            }
-        }
-    }
-
-    // MARK: Convenience methods
-
-    public func animate(with keyboardNotification: Notification, safeAreaInsets: UIEdgeInsets = UIEdgeInsets.zero) {
-        guard let sheetPresentationController = navigationController?.presentationController as? SheetPresentationController else { return }
-        sheetPresentationController.animateContainerView(with: keyboardNotification, safeAreaInsets: safeAreaInsets)
-    }
-}
 
 final class SheetPresentationController: UIPresentationController {
 

--- a/BottomHalfModal/SheetPresentationDelegate.swift
+++ b/BottomHalfModal/SheetPresentationDelegate.swift
@@ -1,0 +1,39 @@
+//
+//  SheetPresentationDelegate.swift
+//  BottomHalfModal
+//
+//  Created by masamichi on 2019/10/09.
+//  Copyright © 2019 merpay, Inc. All rights reserved.
+//
+
+import UIKit
+
+public class SheetPresentationDelegate: NSObject {
+
+    public static var `default`: SheetPresentationDelegate = {
+        return SheetPresentationDelegate()
+    }()
+
+}
+
+extension SheetPresentationDelegate: UIViewControllerTransitioningDelegate {
+    public func presentationController(
+        forPresented presented: UIViewController,
+        presenting: UIViewController?,
+        source: UIViewController
+        ) -> UIPresentationController? {
+        return SheetPresentationController(presentedViewController: presented, presenting: presenting)
+    }
+
+    public func animationController(
+        forPresented presented: UIViewController,
+        presenting: UIViewController,
+        source: UIViewController
+        ) -> UIViewControllerAnimatedTransitioning? {
+        return SheetAnimationController(forPresenting: true)
+    }
+
+    public func animationController(forDismissed dismissed: UIViewController) -> UIViewControllerAnimatedTransitioning? {
+        return SheetAnimationController(forPresenting: false)
+    }
+}

--- a/BottomHalfModal/SheetPresenter.swift
+++ b/BottomHalfModal/SheetPresenter.swift
@@ -1,0 +1,21 @@
+//
+//  SheetPresenter.swift
+//  BottomHalfModal
+//
+//  Created by masamichi on 2019/10/09.
+//  Copyright © 2019 merpay, Inc. All rights reserved.
+//
+
+import UIKit
+
+public protocol SheetPresenter {
+    func presentBottomHalfModal(_ viewControllerToPresent: UIViewController, animated: Bool, completion: (() -> Void)?)
+}
+
+extension UIViewController: SheetPresenter {
+    public func presentBottomHalfModal(_ viewControllerToPresent: UIViewController, animated: Bool, completion: (() -> Void)?) {
+        viewControllerToPresent.modalPresentationStyle = .custom
+        viewControllerToPresent.transitioningDelegate = SheetPresentationDelegate.default
+        present(viewControllerToPresent, animated: animated, completion: completion)
+    }
+}

--- a/BottomHalfModalDemo.xcodeproj/project.pbxproj
+++ b/BottomHalfModalDemo.xcodeproj/project.pbxproj
@@ -19,6 +19,11 @@
 		2439F2B6232A19DF00B5BAD4 /* SheetPresentationController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2439F2B5232A19DF00B5BAD4 /* SheetPresentationController.swift */; };
 		2439F2B8232A1CB800B5BAD4 /* BottomHalfModal.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 2439F2A9232A188000B5BAD4 /* BottomHalfModal.framework */; };
 		2439F2BA232A1CC400B5BAD4 /* BottomHalfModal.framework in Embed Frameworks */ = {isa = PBXBuildFile; fileRef = 2439F2A9232A188000B5BAD4 /* BottomHalfModal.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
+		244FD882234DBB7F00622877 /* SheetPresentationDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 244FD881234DBB7F00622877 /* SheetPresentationDelegate.swift */; };
+		244FD884234DBBA400622877 /* SheetPresenter.swift in Sources */ = {isa = PBXBuildFile; fileRef = 244FD883234DBBA400622877 /* SheetPresenter.swift */; };
+		244FD886234DBBDA00622877 /* SheetContentHeightModifiable.swift in Sources */ = {isa = PBXBuildFile; fileRef = 244FD885234DBBDA00622877 /* SheetContentHeightModifiable.swift */; };
+		244FD888234DBC1000622877 /* SheetControllerContentSizing.swift in Sources */ = {isa = PBXBuildFile; fileRef = 244FD887234DBC1000622877 /* SheetControllerContentSizing.swift */; };
+		244FD88A234DBC3100622877 /* SheetContentHeight.swift in Sources */ = {isa = PBXBuildFile; fileRef = 244FD889234DBC3100622877 /* SheetContentHeight.swift */; };
 		24764069232B1C5E00A2B7F0 /* BasicViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 24764067232B1C5E00A2B7F0 /* BasicViewController.swift */; };
 		2476406A232B1C5E00A2B7F0 /* BasicViewController.xib in Resources */ = {isa = PBXBuildFile; fileRef = 24764068232B1C5E00A2B7F0 /* BasicViewController.xib */; };
 		24764071232B1F9200A2B7F0 /* NavigationViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2476406F232B1F9200A2B7F0 /* NavigationViewController.swift */; };
@@ -76,6 +81,11 @@
 		2439F2B3232A19B700B5BAD4 /* SheetAnimationController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SheetAnimationController.swift; sourceTree = "<group>"; };
 		2439F2B5232A19DF00B5BAD4 /* SheetPresentationController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SheetPresentationController.swift; sourceTree = "<group>"; };
 		2439F2BF232A1D2300B5BAD4 /* TableViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TableViewController.swift; sourceTree = "<group>"; };
+		244FD881234DBB7F00622877 /* SheetPresentationDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SheetPresentationDelegate.swift; sourceTree = "<group>"; };
+		244FD883234DBBA400622877 /* SheetPresenter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SheetPresenter.swift; sourceTree = "<group>"; };
+		244FD885234DBBDA00622877 /* SheetContentHeightModifiable.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SheetContentHeightModifiable.swift; sourceTree = "<group>"; };
+		244FD887234DBC1000622877 /* SheetControllerContentSizing.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SheetControllerContentSizing.swift; sourceTree = "<group>"; };
+		244FD889234DBC3100622877 /* SheetContentHeight.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SheetContentHeight.swift; sourceTree = "<group>"; };
 		24764067232B1C5E00A2B7F0 /* BasicViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BasicViewController.swift; sourceTree = "<group>"; };
 		24764068232B1C5E00A2B7F0 /* BasicViewController.xib */ = {isa = PBXFileReference; lastKnownFileType = file.xib; path = BasicViewController.xib; sourceTree = "<group>"; };
 		2476406F232B1F9200A2B7F0 /* NavigationViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NavigationViewController.swift; sourceTree = "<group>"; };
@@ -182,10 +192,15 @@
 			isa = PBXGroup;
 			children = (
 				2439F2AB232A188000B5BAD4 /* BottomHalfModal.h */,
-				2439F2AC232A188000B5BAD4 /* Info.plist */,
 				2439F2B1232A193700B5BAD4 /* BottomHalfModalNavigationController.swift */,
+				2439F2AC232A188000B5BAD4 /* Info.plist */,
 				2439F2B3232A19B700B5BAD4 /* SheetAnimationController.swift */,
+				244FD889234DBC3100622877 /* SheetContentHeight.swift */,
+				244FD885234DBBDA00622877 /* SheetContentHeightModifiable.swift */,
+				244FD887234DBC1000622877 /* SheetControllerContentSizing.swift */,
 				2439F2B5232A19DF00B5BAD4 /* SheetPresentationController.swift */,
+				244FD881234DBB7F00622877 /* SheetPresentationDelegate.swift */,
+				244FD883234DBBA400622877 /* SheetPresenter.swift */,
 			);
 			path = BottomHalfModal;
 			sourceTree = "<group>";
@@ -369,8 +384,13 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				244FD88A234DBC3100622877 /* SheetContentHeight.swift in Sources */,
+				244FD886234DBBDA00622877 /* SheetContentHeightModifiable.swift in Sources */,
 				2439F2B4232A19B700B5BAD4 /* SheetAnimationController.swift in Sources */,
 				2439F2B6232A19DF00B5BAD4 /* SheetPresentationController.swift in Sources */,
+				244FD888234DBC1000622877 /* SheetControllerContentSizing.swift in Sources */,
+				244FD884234DBBA400622877 /* SheetPresenter.swift in Sources */,
+				244FD882234DBB7F00622877 /* SheetPresentationDelegate.swift in Sources */,
 				2439F2B2232A193700B5BAD4 /* BottomHalfModalNavigationController.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;

--- a/Demo/DemoViewController.swift
+++ b/Demo/DemoViewController.swift
@@ -22,35 +22,42 @@ final class DemoViewController: UITableViewController {
                 text: "Basic",
                 action: { [weak self] in
                     let nav = BottomHalfModalNavigationController(rootViewController: BasicViewController())
-                    self?.navigationController?.present(nav, animated: true, completion: nil)
+                    self?.presentBottomHalfModal(nav, animated: true, completion: nil)
                 }
             ),
             (
                 text: "TableView",
                 action: { [weak self] in
                     let nav = BottomHalfModalNavigationController(rootViewController: TableViewController(style: .plain))
-                    self?.present(nav, animated: true, completion: nil)
+                    self?.presentBottomHalfModal(nav, animated: true, completion: nil)
                 }
             ),
             (
                 text: "Navigation",
                 action: { [weak self] in
                     let nav = BottomHalfModalNavigationController(rootViewController: NavigationViewController())
-                    self?.present(nav, animated: true, completion: nil)
+                    self?.presentBottomHalfModal(nav, animated: true, completion: nil)
                 }
             ),
             (
                 text: "Sticky Button",
                 action: { [weak self] in
                     let nav = BottomHalfModalNavigationController(rootViewController: StickyButtonViewController())
-                    self?.present(nav, animated: true, completion: nil)
+                    self?.presentBottomHalfModal(nav, animated: true, completion: nil)
                 }
             ),
             (
                 text: "Input",
                 action: { [weak self] in
                     let nav = BottomHalfModalNavigationController(rootViewController: InputViewController())
-                    self?.present(nav, animated: true, completion: nil)
+                    self?.presentBottomHalfModal(nav, animated: true, completion: nil)
+                }
+            ),
+            (
+                text: "Without NavigationController",
+                action: { [weak self] in
+                    let vc = StickyButtonViewController()
+                    self?.presentBottomHalfModal(vc, animated: true, completion: nil)
                 }
             )
         ]
@@ -72,6 +79,7 @@ final class DemoViewController: UITableViewController {
         let cell = tableView.dequeueReusableCell(withIdentifier: "Cell", for: indexPath)
         let (text, _) = cells[indexPath.row]
         cell.textLabel?.text = text
+        cell.textLabel?.numberOfLines = 0
         return cell
     }
 

--- a/Demo/Navigation/NavigationViewController.swift
+++ b/Demo/Navigation/NavigationViewController.swift
@@ -47,14 +47,14 @@ final class NavigationViewController: UIViewController, SheetContentHeightModifi
     @IBAction private func presentAnotherHalfModal(_ sender: Any) {
         let vc = PresentViewController()
         let nav = BottomHalfModalNavigationController(rootViewController: vc)
-        present(nav, animated: true, completion: nil)
+        presentBottomHalfModal(nav, animated: true, completion: nil)
     }
 
     @IBAction private func presentOverCurrentContext(_ sender: Any) {
         let vc = PresentOverCurrentContextViewController()
-        let nav = UINavigationController(rootViewController: vc)
+        let nav = BottomHalfModalNavigationController(rootViewController: vc)
         nav.modalPresentationStyle = .overCurrentContext
-        present(nav, animated: true, completion: nil)
+        presentBottomHalfModal(nav, animated: true, completion: nil)
     }
 
     @IBAction private func presentOverFullScreen(_ sender: Any) {

--- a/README.md
+++ b/README.md
@@ -37,6 +37,22 @@ class XXXXViewController: SheetContentHeightModifiable {
 
 ```
 
+Then, call `presentBottomHalfModal(_ viewControllerToPresent: UIViewController, animated: Bool, completion: (() -> Void)?)` to show  the content.
+
+```swift
+    let vc = XXXXViewController()
+    presentBottomHalfModal(vc, animated: true, completion: nil)
+```
+
+If you want to use `UINavigationController` in BottomHalfModal, use `BottomHalfModalNavigationController`. It handles content height update while push and pop navigations.
+
+```swift
+    let vc = XXXXViewController()
+    let nav = BottomHalfNavigationController(rootViewController: vc)
+    presentBottomHalfModal(nav, animated: true, completion: nil)
+```
+
+
 If you support multiple device orientation, please call `adjustFrameToSheetContentHeightIfNeeded()` in `viewWillTransition(to size: CGSize, with coordinator: UIViewControllerTransitionCoordinator)` too.
 
 ```swift
@@ -45,7 +61,6 @@ override func viewWillTransition(to size: CGSize, with coordinator: UIViewContro
     adjustFrameToSheetContentHeightIfNeeded(with: coordinator)
 }
 ```
-
 
 ## Demo
 


### PR DESCRIPTION
Please read the CLA carefully before submitting your contribution to Mercari.
Under any circumstances, by submitting your contribution, you are deemed to accept and agree to be bound by the terms and conditions of the CLA.

https://www.mercari.com/cla/

----

Previous implementation needs to use `BottomHalfModalNavigationController` to present BottomHalfModal.

By this feature, any `UIViewController` can be presented by `presentBottomHalfModal`.

![extension](https://user-images.githubusercontent.com/1473923/66459880-cdd5df00-eab0-11e9-9d86-08c5430e15b9.gif)


