### PR TITLE
fix version written on podspec

### DIFF
--- a/BottomHalfModal.podspec
+++ b/BottomHalfModal.podspec
@@ -8,7 +8,7 @@
 
 Pod::Spec.new do |spec|
   spec.name         = "BottomHalfModal"
-  spec.version      = "1.0.0"
+  spec.version      = "1.1.1"
   spec.summary      = "A customizable bottom half modal used in merpay"
 
   spec.description  = <<-DESC


### PR DESCRIPTION
### WHAT
fix version written on podspec.

### WHY
To enable to install `BottomHalfModal` of latest version by CocoaPods.
See detail on [#3]