### PR TITLE
Update Readme for renamed class name

### DIFF
--- a/BottomHalfModal/BottomHalfModalNavigationController.swift
+++ b/BottomHalfModal/BottomHalfModalNavigationController.swift
@@ -1,5 +1,5 @@
 //
-//  BottomHalfNavigationController.swift
+//  BottomHalfModalNavigationController.swift
 //  BottomHalfModal
 //
 //  Created by ku on 2018/04/26.

--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ If you want to use `UINavigationController` in BottomHalfModal, use `BottomHalfM
 
 ```swift
     let vc = XXXXViewController()
-    let nav = BottomHalfNavigationController(rootViewController: vc)
+    let nav = BottomHalfModalNavigationController(rootViewController: vc)
     presentBottomHalfModal(nav, animated: true, completion: nil)
 ```
 


### PR DESCRIPTION
`BottomHalfNavigationController` is apparently renamed to `BottomHalfModalNavigationController`.